### PR TITLE
Update application accent colors to match system

### DIFF
--- a/ui-base/src/main/res/values/colors.xml
+++ b/ui-base/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
 
   <color name="colorPrimary">#222327</color>
   <color name="colorPrimaryDark">#121212</color>
-  <color name="colorAccent">#F44336</color>
+  <color name="colorAccent">@android:color/system_accent1_300</color>
   <color name="colorError">#F44336</color>
 
   <color name="colorTransparent">#00000000</color>

--- a/ui-base/src/main/res/values/styles.xml
+++ b/ui-base/src/main/res/values/styles.xml
@@ -46,8 +46,8 @@
     <item name="colorSeparator">@color/colorGrayDark</item>
     <item name="colorChipButtonStroke">#66AAAAAA</item>
     <item name="colorCardBackground">#282828</item>
-    <item name="colorBadgeBackground">@color/colorGrayDark</item>
     <item name="colorSheetBackground">@color/colorPrimary</item>
+    <item name="colorBadgeBackground">@android:color/system_accent1_700</item>
     <item name="colorWidgetStatusBackground">@color/colorBlackTranslucent</item>
   </style>
 
@@ -307,7 +307,7 @@
 
   <style name="ShowlySwitch.Overlay" parent="">
     <item name="colorPrimary">@color/colorAccent</item>
-    <item name="colorPrimaryContainer">#4DF44336</item>
+    <item name="colorPrimaryContainer">@android:color/system_accent1_600</item>
   </style>
 
   <style name="ShowlyChip" parent="Widget.Material3.Chip.Suggestion">

--- a/ui-widgets/src/main/res/drawable/bg_widget.xml
+++ b/ui-widgets/src/main/res/drawable/bg_widget.xml
@@ -4,5 +4,5 @@
   android:shape="rectangle"
   >
   <corners android:radius="@dimen/widgetCorner" />
-  <solid android:color="?attr/colorWidgetBackground" />
+  <solid android:color="?attr/colorWidgetBackground25" />
 </shape>

--- a/ui-widgets/src/main/res/values/styles.xml
+++ b/ui-widgets/src/main/res/values/styles.xml
@@ -9,11 +9,11 @@
     <item name="colorWidgetBackground25">#41121212</item>
     <item name="colorWidgetBackground0">#00121212</item>
     <item name="android:textColorPrimary">@color/colorWhite</item>
-    <item name="android:textColorSecondary">@color/colorGrayLight</item>
+    <item name="android:textColorSecondary">#D1D1D1</item>
     <item name="colorPlaceholderIcon">#6A6A6A</item>
     <item name="colorPlaceholderStroke">#6A6A6A</item>
-    <item name="colorAccent">#F44336</item>
-    <item name="colorBadgeBackground">@color/colorGrayDark</item>
+    <item name="colorAccent">@android:color/system_accent1_300</item>
+    <item name="colorBadgeBackground">@android:color/system_accent1_600</item>
   </style>
 
   <style name="AppTheme.Widget.Light" parent="AppTheme">


### PR DESCRIPTION
This PR includes changes to the application's accent colors to align with the user's phone accent colors. (#723)

## Changes
Modified project style files and implemented the use of system_accent1_XXX variables.

## Potential Improvement
Add the original Showly accent color as an option in the settings.
Change the accent color of the app icon.

**Note 1:** If there are any necessary adjustments to the color layout, please feel free to flag them so I can improve the PR.
**Note 2:** If the idea of changing the accent color is not well-received due to branding guidelines, feel free to close this PR.

Attached are examples with different colors:

![image](https://github.com/user-attachments/assets/1eb60837-cccc-4f85-af16-5d706a9b610f)
